### PR TITLE
chore: fix error with csv integration (#15)

### DIFF
--- a/config/grain.json
+++ b/config/grain.json
@@ -7,5 +7,5 @@
     }
   ],
   "maxSimultaneousDistributions": 4,
-  "integration": { "type": "csv", "config": { "gnosis": true } }
+  "integration": "csv"
 }


### PR DESCRIPTION
Fix JSON parse error:
```javascript
% yarn grain -s
yarn run v1.22.18
$ sourcecred grain -s
Error: key "integration": expected csv, got object
    at Parser.parseOrThrow (webpack:///./src/util/combo.js?:27:227)
    at loadJson (webpack:///./src/util/storage.js?:14:102)
    at async Promise.all (index 2)
    at async LocalInstance.readGrainInput (webpack:///./src/api/instance/readInstance.js?:30:755)
    at async grainCommand (webpack:///./src/cli/grain.js?:10:815)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

According to the [SourceCred documentation](https://sourcecred.io/docs/guides/csv-grain/), adding this line would generate CSVs compatible with Gnosis Safe:
```javascript
"integration": { "type": "csv", "config": { "gnosis": true } }
```
However, this resulted in the error above. Changing from a JSON object to "csv" solved the bug: https://github.com/nation3/nationcred-instance/pull/21/files
```javascript
 % yarn grain -s
yarn run v1.22.18
$ sourcecred grain -s
——SIMULATED DISTRIBUTION——
Distributed 1g to 2 identities in 4 distributions

```
