### PR TITLE
chore: set custom reaction weight for channels (#10)

### DIFF
--- a/config/plugins/sourcecred/discord/config.json
+++ b/config/plugins/sourcecred/discord/config.json
@@ -3,6 +3,13 @@
     "channelWeightConfig": {
       "defaultWeight": 1,
       "weights": {
+        "966350001469014016// 🇺🇳☁welcome-to-nation3": 0,
+        "953369789840105543// 👉-onboarding": 0,
+        "963777267950034954// 📚-resources": 0,
+        "963777344106012694// 🌍-discord-map": 0,
+        "966344727295307856// 🤖-guild-join": 0,
+        "963777722600009779// 👉-start-here": 0,
+        "968874858576494642// 📣-announcements": 0
       }
     },
     "guildId": "690584551239581708",


### PR DESCRIPTION
Configure zero reaction weight for posts in announcement/read-only Discord channels.

<img width="622" alt="Screen Shot 2022-05-13 at 8 14 11 AM" src="https://user-images.githubusercontent.com/95955389/168195831-9fdb7c92-13e0-44a2-8ea1-335b66841306.png">
