### PR TITLE
refactor: configure props channel (#10)

### DIFF
--- a/config/plugins/sourcecred/discord/config.json
+++ b/config/plugins/sourcecred/discord/config.json
@@ -15,7 +15,7 @@
     "guildId": "690584551239581708",
     "includeNsfwChannels": false,
     "propsChannels": [
-      "974617363234324510// 🎗-nationcred"
+      "974617363234324510"
     ],
     "reactionWeightConfig": {
       "applyAveraging": false,


### PR DESCRIPTION
The documentation at https://sourcecred.io/docs/beta/plugins/discord#propschannels does not specifically mention support for including comments inside a `propsChannels` ID as it does for channel weights (https://sourcecred.io/docs/beta/plugins/discord#channelweightconfig).

So removing the comment to ensure that the props channel loads correctly.