### PR TITLE
chore: remove obsolete github repo (#42)

### DIFF
--- a/config/plugins/sourcecred/github/config.json
+++ b/config/plugins/sourcecred/github/config.json
@@ -3,7 +3,6 @@
         "nation3/animated-3d-card",
         "nation3/app",
         "nation3/brand",
-        "nation3/coordinape",
         "nation3/court",
         "nation3/dune-projects",
         "nation3/email-tweetdrop",


### PR DESCRIPTION
The code in https://github.com/nation3/coordinape was made obsolete by Parcel.

#42