### PR TITLE
chore: limit to one dependency update at the time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 1
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
https://app.dework.xyz/nation3/develop-1?taskId=10364f69-c9f8-4c70-8c55-aeb2984fcfec

Makes it easier to handle breaking changes.