### PR TITLE
Keep all the files in the output folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,3 @@ cache/
 **/.DS_Store?
 
 yarn-error.log
-
-#  Ignore all content under output/ except CSV folder (output/grainIntegration/)
-output/credGrainView
-output/credGraph
-output/graphs/


### PR DESCRIPTION
Keep all the files in the output folder.

## Dework Task
https://app.dework.xyz/nation3/n3bi?taskId=ce09cd98-ea6a-4b46-8ed1-930f4454a605

## How Has This Been Tested?

Ran the weekly automated process by creating a `grain-trigger` branch and checked that the created PR contained the database files - it did. 